### PR TITLE
chore(rebrand): metadata & NOTICE (no code changes)

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,0 +1,9 @@
+# NOTICE
+
+This repository is an **independent fork** of upstream Uniswap code and is **not affiliated with or endorsed by Uniswap**.
+
+- Upstream source: git@github.com:Uniswap/interface.git
+- Copyrights and licenses remain with their respective owners.
+- See `LICENSE` for full licensing terms of this repository. Some upstream components may be under different licenses; consult upstream for details.
+
+This fork primarily changes branding and build/release metadata at this stage. Functional changes (if any) will be documented in release notes and pull requests.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+> **Independent fork** — not affiliated with Uniswap. See NOTICE.md.
+
 # Uniswap Labs: Front End Interfaces
 
 This is the **public** repository for Uniswap Labs’ front-end interfaces, including the Web App, Wallet Mobile App, and Wallet Extension. Uniswap is a protocol for decentralized exchange of Ethereum-based assets.

--- a/package.json
+++ b/package.json
@@ -194,5 +194,14 @@
     "apps/*",
     "packages/*",
     "config/*"
-  ]
+  ],
+  "description": "PrimeaSwap interface — independent fork",
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/primeanetwork/interface.git"
+  },
+  "bugs": {
+    "url": "https://github.com/primeanetwork/interface/issues"
+  },
+  "homepage": "https://primea.network"
 }


### PR DESCRIPTION
Adds `NOTICE.md`, injects an in-repo banner in `README.md`, and updates `package.json` metadata fields to point to `primeanetwork/interface`. **No product code changes.**