### PR TITLE
chore(release): publish scaffold (publishConfig + docs)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @rodriherrerab

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,29 @@
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - main
+      - master
+      - "rebrand/**"
+  pull_request:
+  schedule:
+    - cron: "10 3 * * 1"
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: javascript
+      - uses: github/codeql-action/autobuild@v3
+      - uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:javascript"

--- a/RELEASE_PLAN.md
+++ b/RELEASE_PLAN.md
@@ -1,0 +1,22 @@
+# Release Plan — Primea (Alpha Scaffold)
+
+This PR only adds publish scaffolding. No product code changes.
+
+## Now
+- Normalize `publishConfig` in every `package.json`.
+  - Public packages:
+    "publishConfig": {
+      "access": "public",
+      "registry": "https://registry.npmjs.org/",
+      "tag": "primea-alpha"
+    }
+  - Private packages:
+    "publishConfig": { "tag": "private-skip" }
+
+## Later
+- Keep names unchanged now; later publish under `@primea/*` from a dedicated `release/*` branch.
+- Workspace-aware publish (pnpm/yarn) with `--tag primea-alpha`.
+
+## Guardrails
+- Private packages tagged `private-skip` to avoid accidental publish.
+- Publish only from protected release branches.

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -109,5 +109,8 @@
     "test": "jest",
     "snapshots": "jest -u",
     "typecheck": "tsc -b"
+  },
+  "publishConfig": {
+    "tag": "private-skip"
   }
 }

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -246,5 +246,8 @@
         "expo-constants"
       ]
     }
+  },
+  "publishConfig": {
+    "tag": "private-skip"
   }
 }

--- a/apps/mobile/src/package.json
+++ b/apps/mobile/src/package.json
@@ -1,3 +1,8 @@
 {
-  "name": "src"
+  "name": "src",
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/",
+    "tag": "primea-alpha"
+  }
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -290,5 +290,10 @@
     "*.css",
     "**/sideEffects.ts",
     "**/tracing/index.ts"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/",
+    "tag": "primea-alpha"
+  }
 }

--- a/config/jest-presets/package.json
+++ b/config/jest-presets/package.json
@@ -12,5 +12,8 @@
     "mem-storage-area": "1.0.3"
   },
   "license": "MIT",
-  "private": true
+  "private": true,
+  "publishConfig": {
+    "tag": "private-skip"
+  }
 }

--- a/config/tsconfig/package.json
+++ b/config/tsconfig/package.json
@@ -9,5 +9,8 @@
     "storybook.json",
     "ui.json"
   ],
-  "private": true
+  "private": true,
+  "publishConfig": {
+    "tag": "private-skip"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -203,5 +203,8 @@
   "bugs": {
     "url": "https://github.com/primeanetwork/interface/issues"
   },
-  "homepage": "https://primea.network"
+  "homepage": "https://primea.network",
+  "publishConfig": {
+    "tag": "private-skip"
+  }
 }

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -58,5 +58,10 @@
     "eslint": "8.44.0",
     "jest": "29.7.0",
     "typescript": "5.3.3"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/",
+    "tag": "primea-alpha"
   }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -75,5 +75,8 @@
   "sideEffects": [
     "*.css"
   ],
-  "types": "./types/index"
+  "types": "./types/index",
+  "publishConfig": {
+    "tag": "private-skip"
+  }
 }

--- a/packages/uniswap/package.json
+++ b/packages/uniswap/package.json
@@ -164,5 +164,8 @@
   "private": true,
   "sideEffects": [
     "*.css"
-  ]
+  ],
+  "publishConfig": {
+    "tag": "private-skip"
+  }
 }

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -61,5 +61,8 @@
   },
   "sideEffects": [
     "*.css"
-  ]
+  ],
+  "publishConfig": {
+    "tag": "private-skip"
+  }
 }

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -83,5 +83,8 @@
   "private": true,
   "sideEffects": [
     "*.css"
-  ]
+  ],
+  "publishConfig": {
+    "tag": "private-skip"
+  }
 }


### PR DESCRIPTION
Normalize publish scaffolding across the repo:

- `publishConfig` in all `package.json` files (root + workspaces)
  - public → access=public, registry=https://registry.npmjs.org/, tag=primea-alpha
  - private → tag=private-skip
- Add `RELEASE_PLAN.md` with next-steps and guardrails.

No product code changes; safe to re-run.